### PR TITLE
Corrected "Required" attribute

### DIFF
--- a/code/pagetypes/SubscriptionPage.php
+++ b/code/pagetypes/SubscriptionPage.php
@@ -307,7 +307,7 @@ class SubscriptionPage_Controller extends Page_Controller
         );
 
         if (!empty($requiredFields)) {
-            $required = new RequiredFields($requiredFields);
+            $required = new RequiredFields(array_keys($requiredFields));
         } else {
             $required = null;
         }


### PR DESCRIPTION
the `$requiredFields` will now return a correct HTML (example `<input>` tag) with attribute `required` if this field is required.
